### PR TITLE
Manage file descriptor

### DIFF
--- a/lib/fileReader.js
+++ b/lib/fileReader.js
@@ -1,0 +1,30 @@
+const fs = require('fs');
+
+/**
+ * @param {string} filePath
+ * @returns {Object}
+ */
+const init = function (filePath) {
+  let fd = fs.openSync(filePath, 'r');
+
+  /**
+   * @returns {string}
+   */
+  const read = function () {
+    return fs.readFileSync(fd).toString();
+  };
+
+  const close = function () {
+    if (typeof fd === 'number') {
+      fs.closeSync(fd);
+      fd = null;
+    }
+  };
+
+  return {
+    read: read,
+    close: close,
+  }
+};
+
+module.exports.init = init;

--- a/lib/indexUtil.js
+++ b/lib/indexUtil.js
@@ -61,7 +61,9 @@ const getTitle = function (baseDir, path) {
   const liner = new LineByLine(baseDir + '/' + path);
   const result = getTitleLine(liner, path);
 
-  liner.close();
+  if (typeof liner.fd === 'number') {
+    liner.close();
+  }
 
   return result;
 };

--- a/lib/indexUtil.js
+++ b/lib/indexUtil.js
@@ -59,7 +59,19 @@ const encodePath = function(path) {
  */
 const getTitle = function (baseDir, path) {
   const liner = new LineByLine(baseDir + '/' + path);
+  const result = getTitleLine(liner, path);
 
+  liner.close();
+
+  return result;
+};
+
+/**
+ * @param {LineByLine} liner
+ * @param {string} path
+ * @returns {string}
+ */
+const getTitleLine = function (liner, path) {
   /** @var {Buffers} */
   let line;
 

--- a/lib/indexUtil.js
+++ b/lib/indexUtil.js
@@ -74,7 +74,7 @@ const getTitle = function (baseDir, path) {
  * @returns {string}
  */
 const getTitleLine = function (liner, path) {
-  /** @var {Buffers} */
+  /** @var {Buffer} */
   let line;
 
   /** @var {string} */

--- a/lib/middleware.search.js
+++ b/lib/middleware.search.js
@@ -19,20 +19,22 @@ const main = function (userFileDir) {
 
     if (matcher.countPatterns() > 0) {
       indexUtil.scanMarkdownFiles(userFileDir).forEach(function (item) {
+        /** @type {number} file descriptor */
+        let fd;
+
         try {
           const filePath = fs.realpathSync(userFileDir + '/' + item.notation);
-          /** @type {number} file descriptor */
-          const fd = fs.openSync(filePath, 'r');
+          fd = fs.openSync(filePath, 'r');
           const content = fs.readFileSync(fd).toString();
 
           if (matcher.matches(content)) {
             result.push(item);
           }
-
-          fs.closeSync(fd);
         } catch (e) {
           /* istanbul ignore next */
           console.log(e);
+        } finally {
+          fs.closeSync(fd);
         }
       });
     }

--- a/lib/middleware.search.js
+++ b/lib/middleware.search.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const fileReader = require('./fileReader');
 const indexUtil = require('./indexUtil');
 const searchUtil = require('./searchUtil');
 
@@ -19,23 +20,18 @@ const main = function (userFileDir) {
 
     if (matcher.countPatterns() > 0) {
       indexUtil.scanMarkdownFiles(userFileDir).forEach(function (item) {
-        /** @type {number} file descriptor */
-        let fd;
-
         try {
           const filePath = fs.realpathSync(userFileDir + '/' + item.notation);
+          const reader = fileReader.init(filePath);
 
-          fd = fs.openSync(filePath, 'r');
-          if (matcher.matches(fs.readFileSync(fd).toString())) {
+          if (matcher.matches(reader.read())) {
             result.push(item);
           }
+
+          reader.close();
         } catch (e) {
           /* istanbul ignore next */
           console.log(e);
-        } finally {
-          if (typeof fd === 'number') {
-            fs.closeSync(fd);
-          }
         }
       });
     }

--- a/lib/middleware.search.js
+++ b/lib/middleware.search.js
@@ -21,11 +21,15 @@ const main = function (userFileDir) {
       indexUtil.scanMarkdownFiles(userFileDir).forEach(function (item) {
         try {
           const filePath = fs.realpathSync(userFileDir + '/' + item.notation);
-          const content = fs.readFileSync(filePath).toString();
+          /** @type {number} file descriptor */
+          const fd = fs.openSync(filePath, 'r');
+          const content = fs.readFileSync(fd).toString();
 
           if (matcher.matches(content)) {
             result.push(item);
           }
+
+          fs.closeSync(fd);
         } catch (e) {
           /* istanbul ignore next */
           console.log(e);

--- a/lib/middleware.search.js
+++ b/lib/middleware.search.js
@@ -25,9 +25,8 @@ const main = function (userFileDir) {
         try {
           const filePath = fs.realpathSync(userFileDir + '/' + item.notation);
           fd = fs.openSync(filePath, 'r');
-          const content = fs.readFileSync(fd).toString();
 
-          if (matcher.matches(content)) {
+          if (matcher.matches(fs.readFileSync(fd).toString())) {
             result.push(item);
           }
         } catch (e) {

--- a/lib/middleware.search.js
+++ b/lib/middleware.search.js
@@ -24,8 +24,8 @@ const main = function (userFileDir) {
 
         try {
           const filePath = fs.realpathSync(userFileDir + '/' + item.notation);
-          fd = fs.openSync(filePath, 'r');
 
+          fd = fs.openSync(filePath, 'r');
           if (matcher.matches(fs.readFileSync(fd).toString())) {
             result.push(item);
           }
@@ -33,7 +33,9 @@ const main = function (userFileDir) {
           /* istanbul ignore next */
           console.log(e);
         } finally {
-          fs.closeSync(fd);
+          if (typeof fd === 'number') {
+            fs.closeSync(fd);
+          }
         }
       });
     }


### PR DESCRIPTION
- #4
- #6

File descriptor error

```
{
  Error: ENFILE: file table overflow, open '/<files_dir>//file.md'
    at Object.openSync (fs.js:436:3)
    at new LineByLine (/<project>/node_modules/n-readlines/readlines.js:23:26)
    at getTitle (/<project>/lib/indexUtil.js:53:17)
    at /<project>/lib/indexUtil.js:29:14
    at Array.forEach (<anonymous>)
    at Object.scanMarkdownFiles (/<project>/lib/indexUtil.js:24:55)
    at /<project>/lib/middleware.search.js:25:15
    at Layer.handle [as handle_request] (/<project>/node_modules/express/lib/router/layer.js:95:5)
    at next (/<project>/node_modules/express/lib/router/route.js:137:13)
    at Route.dispatch (/<project>/node_modules/express/lib/router/route.js:112:3)
  errno: -23,
  syscall: 'open',
  code: 'ENFILE',
  path: '/<files_dir>//file.md'
}
```
### Note
- There are 1000 markdown files under <files_dir>.